### PR TITLE
Use Authentic.settings.sign_in_key

### DIFF
--- a/src/framework_handlers/authentic_handler.cr
+++ b/src/framework_handlers/authentic_handler.cr
@@ -7,7 +7,7 @@ module Honeybadger
   class AuthenticHandler
     include HTTP::Handler
 
-    def initialize(*, @factory : Honeybadger::HttpPayload.class = Honeybadger::HttpPayload, @session_key : String = Authentic::ActionHelpers::SIGN_IN_KEY)
+    def initialize(*, @factory : Honeybadger::HttpPayload.class = Honeybadger::HttpPayload, @session_key : String = Authentic.settings.sign_in_key)
     end
 
     def call(context : HTTP::Server::Context)


### PR DESCRIPTION
## Description
Fix compilation error and access sign in key through Authentic settings.