### PR TITLE
Use send over send_async

### DIFF
--- a/src/framework_handlers/authentic_handler.cr
+++ b/src/framework_handlers/authentic_handler.cr
@@ -19,7 +19,7 @@ module Honeybadger
     rescue exception
       payload = @factory.new exception, context.request
 
-      Honeybadger::Dispatch.send_async payload
+      Honeybadger::Dispatch.send payload
 
       raise exception
     end


### PR DESCRIPTION
## Description
- Use send over send_async to send the payload; having issues in production with send_async