### PR TITLE
Fix payload initialization on Crystal 1.21

### DIFF
--- a/spec/support/example_payload.cr
+++ b/spec/support/example_payload.cr
@@ -1,7 +1,7 @@
 module Honeybadger
   class ExamplePayload < Payload
-    def initialize(@exception : Exception = self.class.generate_exception)
-      super(@exception)
+    def initialize(exception : Exception = self.class.generate_exception)
+      super(exception)
     end
 
     # Generates an exception with a backtrace for testing.

--- a/src/honeybadger/http_payload.cr
+++ b/src/honeybadger/http_payload.cr
@@ -9,13 +9,15 @@ module Honeybadger
   # HTTP::Server request cycle.
   class HttpPayload < Payload
     # :inherit:
-    getter exception
+    def exception : Exception
+      @exception.not_nil!
+    end
 
     # The request in which the exception was triggered.
     getter http_request : HTTP::Request
 
-    def initialize(@exception : Exception, @http_request : HTTP::Request)
-      super(@exception)
+    def initialize(exception : Exception, @http_request : HTTP::Request)
+      super(exception)
     end
 
     # Renders the "request" stanza of the json payload.


### PR DESCRIPTION
## Summary

Avoid passing a nilable inherited exception ivar to `Payload#initialize` under Crystal 1.21 strict inference. Preserve the public `HttpPayload#exception` API with an explicit non-nil return type.

## Validation

- Crystal 1.19.2: 81 examples, 0 failures
- Crystal 1.21.0: 81 examples, 0 failures
- Changed files pass `crystal tool format --check`

No runtime behavior or payload schema changes.